### PR TITLE
[CCNB-5696] node 14 tsconfig 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ npm i @ecubelabs/tsconfig
 
 ## Usage
 
-### Node 14 <kbd><a href="./node12.json">tsconfig.json</a></kbd>
+### Node 14 <kbd><a href="./node14.json">tsconfig.json</a></kbd>
 Add to your `tsconfig.json`
 ```
 "extends": "@ecubelabs/tsconfig/node14.json"

--- a/README.md
+++ b/README.md
@@ -4,6 +4,13 @@ npm i @ecubelabs/tsconfig
 ```
 
 ## Usage
+
+### Node 14 <kbd><a href="./node12.json">tsconfig.json</a></kbd>
+Add to your `tsconfig.json`
+```
+"extends": "@ecubelabs/tsconfig/node14.json"
+```
+
 ### Node 12 <kbd><a href="./node12.json">tsconfig.json</a></kbd>
 Add to your `tsconfig.json`
 ```

--- a/node14.json
+++ b/node14.json
@@ -7,6 +7,7 @@
     "target": "es2020",
 
     "module": "es2020",
+    "moduleResolution": "node",
     "noEmitOnError": true,
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,

--- a/node14.json
+++ b/node14.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "display": "Ecube Labs Node 14",
+
+  "compilerOptions": {
+    "lib": ["es2020"],
+    "target": "es2020",
+
+    "module": "es2020",
+    "noEmitOnError": true,
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "resolveJsonModule": true,
+    "removeComments": true,
+    "noErrorTruncation": true,
+    "forceConsistentCasingInFileNames": true,
+    "sourceMap": true,
+    "inlineSources": true
+  }
+}


### PR DESCRIPTION

0. 기존에 작성 된 `node10.json`, `node12.json` 포맷 가져와서 아래 순서대로 필요한 부분만 변경하기로 하였습니다.
1. `”module”: “es2020”` Node 14는 오래 된 CommonJS 포맷 대신 모듈 로딩을 지원하므로 적용
2. `"moduleResolution": "node"` 기존 node 10, node 12에서는 `module: commonjs`를 사용하여 default로 `node` 였으나 `module: es2020`은 default가 classic이 되어버리므로 명시할 필요가 있어서 명시
3. `”lib”: [“es2020”]`을 통해 ES2020에 소개된 함수들과 속성들을 사용할 수 있도록 적용
4. `”target”: “es2020”`을 통해 ouput에서 ES2020 syntax 사용할 수 있도록 적용

ERP-API에서 작성한 tsconfig 적용 후 build (tsc) 테스트까지 진행하였습니다.

위 내용 이외에 부가적인 options들을 우선 기존에 사용되던대로 두었는 데 수정해야할 부분 있으면 리뷰 부탁드립니다.

- [참고 링크](https://stackoverflow.com/questions/61305578/what-typescript-configuration-produces-output-closest-to-node-js-14-capabilities/61305579#61305579)