### PR TITLE
fix: use 'commonjs' as compilerOptions.module

### DIFF
--- a/node14.json
+++ b/node14.json
@@ -6,7 +6,7 @@
     "lib": ["es2020"],
     "target": "es2020",
 
-    "module": "es2020",
+    "module": "commonjs",
     "moduleResolution": "node",
     "noEmitOnError": true,
     "experimentalDecorators": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ecubelabs/tsconfig",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "",
   "main": "node14.json",
   "scripts": {


### PR DESCRIPTION
https://github.com/Ecube-Labs/node-osrm-routed/pull/7/files/8a1a9b3823962e4920189fa6cfdf56253cb92124..b9ce3eba297706732b1db6341beaf11207454d5a#diff-b55cdbef4907b7045f32cc5360d48d262cca5f94062e353089f189f4460039e0

이러한 문제가 있어서 node14.json의 `compilerOptions.module`을 node10, 12와 동일하게 `'commonjs'`로 수정하고자 합니다.
혹시 유지해야 하는 이유가 있다면 알려주세요.

아직 npm publish는 안 했습니다.