### PR TITLE
SW-10419 feat: add node20

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ npm i @ecubelabs/tsconfig
 
 ### Node 20 <kbd><a href="./node20.json">tsconfig.json</a></kbd>
 Add to your `tsconfig.json`
+This tsconfig requires typescript>=5
 ```
 "extends": "@ecubelabs/tsconfig/node20.json"
 ```

--- a/README.md
+++ b/README.md
@@ -5,7 +5,13 @@ npm i @ecubelabs/tsconfig
 
 ## Usage
 
-### Node 18 <kbd><a href="./node16.json">tsconfig.json</a></kbd>
+### Node 20 <kbd><a href="./node20.json">tsconfig.json</a></kbd>
+Add to your `tsconfig.json`
+```
+"extends": "@ecubelabs/tsconfig/node20.json"
+```
+
+### Node 18 <kbd><a href="./node18.json">tsconfig.json</a></kbd>
 Add to your `tsconfig.json`
 ```
 "extends": "@ecubelabs/tsconfig/node18.json"

--- a/node20.json
+++ b/node20.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "display": "Ecube Labs Node 20",
+
+  "compilerOptions": {
+    "lib": ["es2023"],
+    "target": "ES2023",
+    
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "noEmitOnError": true,
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "resolveJsonModule": true,
+    "removeComments": true,
+    "noErrorTruncation": true,
+    "forceConsistentCasingInFileNames": true,
+    "sourceMap": true,
+    "inlineSources": true
+  }
+}

--- a/node20.json
+++ b/node20.json
@@ -6,8 +6,8 @@
     "lib": ["es2023"],
     "target": "ES2022",
     
-    "module": "commonjs",
-    "moduleResolution": "node",
+    "module": "Node16",
+    "moduleResolution": "Node16",
     "noEmitOnError": true,
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,

--- a/node20.json
+++ b/node20.json
@@ -4,7 +4,7 @@
 
   "compilerOptions": {
     "lib": ["es2023"],
-    "target": "ES2023",
+    "target": "ES2022",
     
     "module": "commonjs",
     "moduleResolution": "node",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ecubelabs/tsconfig",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "",
   "main": "node18.json",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ecubelabs/tsconfig",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "",
   "main": "node18.json",
   "scripts": {


### PR DESCRIPTION
## 이슈
https://ecubelabs.atlassian.net/browse/SW-10419

## 변경사항
* `node20.json`을 추가했습니다.
  * lib, ~target~이 `ES2023`으로 바뀐것 외에 `node18.json`과 차이점은 없습니다.
  * node:20-alpine의 node 버전은 [20.1.0](https://github.com/nodejs/docker-node/blob/4bda55337ef11b9b2dbb80ee6576870e258a035b/20/alpine3.17/Dockerfile#L3) 이고 https://node.green/ 에 따르면 node version 20.1.0은 es2023을 지원하므로 ts를 es2023의 js로 컴파일해도 문제 없을 것으로 보입니다.
  * 다만 tsconfig에서 lib, target에 `ES2023`을 사용하려면 typescript의 버전 5부터 가능합니다.